### PR TITLE
Optimize NPB-FT evolve() by using localAccess

### DIFF
--- a/example/NPB-FT/ft.chpl
+++ b/example/NPB-FT/ft.chpl
@@ -88,8 +88,8 @@ writef("MFLOPS : %10.4dr\n",mflops);
 
 proc evolve() {
   forall ijk in Dom {
-    V[ijk] *= Twiddle[ijk];
-    W[ijk] = V[ijk];
+    V.localAccess[ijk] *= Twiddle.localAccess[ijk];
+    W.localAccess[ijk] = V.localAccess[ijk];
   }
   doFFT(W, FFTW_BACKWARD); // This is unnormalized
 }
@@ -131,7 +131,7 @@ proc initialize_twiddle() {
       const x1 = if (i1 >= halfN(ii)) then i1-N(ii) else i1;
       e += x1**2;
     }
-    Twiddle[ijk] = exp(-fac*e);
+    Twiddle.localAccess[ijk] = exp(-fac*e);
   }
 }
 


### PR DESCRIPTION
This eliminates runtime locality checks, which are expensive compared to the
operations being done. This results in a 3-4x speedup for this step of `evolve()`
This just reduces a scalar overhead which improves raw speed, but shouldn't
impact scalability. Here's some data points for size NPB-FT size D on Swan:

| Locales | Before | Now  |
| ------- | ------ | ---- |
| 1       | 300s   | 200s |
| 8       | 100s   |  80s |

Previously this code was:

```chpl
forall ijk in Dom {
  V[ijk] *= Twiddle[ijk];
  W[ijk] = V[ijk];
}
```

and now it is:

```chpl
forall ijk in Dom {
  V.localAccess[ijk] *= Twiddle.localAccess[ijk];
  W.localAccess[ijk] = V.localAccess[ijk];
}
```

Ideally we would write this as:

```chpl
forall (v, t, w) in zip(V, Twiddle, W) {
  v *= t;
  w = v;
}
```

or just:

```chpl
V *= Twiddle;
W = V;
```

But those 2 perform poorly: https://github.com/chapel-lang/chapel/issues/13147