### PR TITLE
Switch PencilFFT-2 doFFT_X_Transposed yChunk forall to a coforall

### DIFF
--- a/src/DistributedFFT.chpl
+++ b/src/DistributedFFT.chpl
@@ -457,8 +457,12 @@ prototype module DistributedFFT {
           const x0 = xRange.first;
           const z0 = zRange.first;
 
+          const numOuterTasks = if yChunk.size >= here.maxTaskPar then here.maxTaskPar
+                                                                  else 1;
+          coforall tid in 0..#numOuterTasks with (ref plan_x) {
+
           var tt = new TimeTracker();
-          for iy in yChunk {
+          for iy in chunk(yChunk, numOuterTasks, tid)  {
             // Copy the data
             tt.start();
             const offset = (xRange.size/numLocales)*here.id;
@@ -477,7 +481,7 @@ prototype module DistributedFFT {
             }
             tt.stop(TimeStages.Execute);
           }
-
+          }
         }
       }
       // End of on-loc

--- a/src/DistributedFFT.chpl
+++ b/src/DistributedFFT.chpl
@@ -457,7 +457,8 @@ prototype module DistributedFFT {
           const x0 = xRange.first;
           const z0 = zRange.first;
 
-          forall iy in yChunk with (ref plan_x, var tt = new TimeTracker()) {
+          var tt = new TimeTracker();
+          for iy in yChunk {
             // Copy the data
             tt.start();
             const offset = (xRange.size/numLocales)*here.id;

--- a/src/DistributedFFT.chpl
+++ b/src/DistributedFFT.chpl
@@ -460,27 +460,26 @@ prototype module DistributedFFT {
           const numOuterTasks = if yChunk.size >= here.maxTaskPar then here.maxTaskPar
                                                                   else 1;
           coforall tid in 0..#numOuterTasks with (ref plan_x) {
+            var tt = new TimeTracker();
+            for iy in chunk(yChunk, numOuterTasks, tid)  {
+              // Copy the data
+              tt.start();
+              const offset = (xRange.size/numLocales)*here.id;
+              forall ix in 0.. #xRange.size {
+                const ix1 = (ix + offset)%xRange.size + x0;
+                ref dstRef = dest.localAccess[iy, ix1, z0];
+                ref srcRef = arr[ix1,iy,z0];
+                __primitive("chpl_comm_get", dstRef, srcRef.locale.id, srcRef, myLineSize);
+              }
+              tt.stop(TimeStages.Comms);
 
-          var tt = new TimeTracker();
-          for iy in chunk(yChunk, numOuterTasks, tid)  {
-            // Copy the data
-            tt.start();
-            const offset = (xRange.size/numLocales)*here.id;
-            forall ix in 0.. #xRange.size {
-              const ix1 = (ix + offset)%xRange.size + x0;
-              ref dstRef = dest.localAccess[iy, ix1, z0];
-              ref srcRef = arr[ix1,iy,z0];
-              __primitive("chpl_comm_get", dstRef, srcRef.locale.id, srcRef, myLineSize);
+              tt.start();
+              forall iz in zRange with (ref plan_x) {
+                var elt = c_ptrTo(dest.localAccess[iy,x0,iz]);
+                plan_x.execute(elt, elt);
+              }
+              tt.stop(TimeStages.Execute);
             }
-            tt.stop(TimeStages.Comms);
-
-            tt.start();
-            forall iz in zRange with (ref plan_x) {
-              var elt = c_ptrTo(dest.localAccess[iy,x0,iz]);
-              plan_x.execute(elt, elt);
-            }
-            tt.stop(TimeStages.Execute);
-          }
           }
         }
       }


### PR DESCRIPTION
Affinity is better when parallelizing over yChunk, but at higher node counts
it's not wide enough to spread across all cores. The inner foralls create
additional tasks, but our current scheduler won't spread them out so we'll end
up doubling some tasks on cores. Here we parallelize yChunk if it'll cover all
cores, otherwise we serialize it and let the inner foralls create the full
parallelism. This improves affinity for low node counts, but still gets us full
parallelism at higher node counts.

Here's performance for Size D:

| Nodes | Master | PencilFFT-2 | inner-for | outer-coforall |
| ----- | ------ | ----------- | --------- | -------------- |
|   1   | 155.5s | 142.5s      | 161.1s    | 143.0s         |
|   2   |  84.7s |  93.2s      | 111.1s    |  92.1s         |
|   4   |  58.1s |  70.3s      |  72.6s    |  69.9s         |
|   8   |  36.2s |  41.4s      |  43.7s    |  40.7s         |
|  16   |  20.5s |  25.3s      |  22.9s    |  24.5s         |
|  32   |  14.2s |  15.3s      |  13.2s    |  13.2s         |
|  64   |   9.4s |   9.3s      |   7.0s    |   7.9s         |
| 128   |   7.1s |   6.5s      |   3.9s    |   3.9s         |
| 256   |   5.9s |   4.0s      |   2.1s    |   2.1s         |
| 512   |   5.6s |   2.4s      |   1.3s    |   1.3s         |


Master -- bf40d24
PencilFFT-2 -- 7b540e0
inner-for -- c9090c3
outer-coforall -- ac57b8c