### PR TITLE
Make some `use`s public

### DIFF
--- a/src/DistributedFFT.chpl
+++ b/src/DistributedFFT.chpl
@@ -34,10 +34,11 @@
 */
 prototype module DistributedFFT {
 
-  use BlockDist;
+  public use BlockDist;
+  public use FFTW;
+
   use AllLocalesBarriers;
   use RangeChunk;
-  use FFTW;
   use FFTW.C_FFTW;
   use FFT_Locks;
   use FFT_Timers;


### PR DESCRIPTION
chapel-lang/chapel#14353 made `use` private by default in user modules.

Update DistributedFFT to have public FFTW and BlockDist uses since Block
is exposed in exported types (slabDom) and it seems natural to expose
FFTW since you'll want FFTW symbols when doing distributed ffts (e.g.
`FFTW_BACKWARD`, `FFTW_FORWARD`)