### PR TITLE
Stop throwing -suseBulkTransfer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NAIVEFLAG=
 endif
 
 # The following are experimental flags for better performance
-PERF_FLAGS=-schpl_serializeSlices -suseBulkTransfer
+PERF_FLAGS=-schpl_serializeSlices
 
 Mason.toml: Mason.toml.template
 	envsubst < $< > $@


### PR DESCRIPTION
`useBulkTransfer` is enabled by default (and has been for some time.) I
think the intended flag was `useBulkTransferDist`, but that's not needed
in 1.20 since chapel-lang/chapel#12797 enabled block bulk-transfer by
default.