### PR TITLE
Add 'use' of SysCTypes and CPtr

### DIFF
--- a/src/DistributedFFT.chpl
+++ b/src/DistributedFFT.chpl
@@ -42,6 +42,7 @@ prototype module DistributedFFT {
   use FFTW.C_FFTW;
   use FFT_Locks;
   use FFT_Timers;
+  use SysCTypes, CPtr;
 
   /*
     Compile time parameters for higher performance.


### PR DESCRIPTION
SysCTypes is no longer available in Chapel code by default, so I'm
adding a [private] use of SysCTypes here to keep this working with
Chapel master.  In addition, we anticipate that CPtr will not be
available by default in Chapel 1.21, so I'm pre-emptively adding
a use of it for similar reasons and to avoid needing to come back
to this later.

I wasn't sure quite how to test this, but these changes seemed to
get things compiling again in the clone of it on chapel-lang/chapel
so hopefully it will work here as well (?).