### PR TITLE
Update to Chapel 1.22 for CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ jobs:
         docker run -it -v ${TRAVIS_BUILD_DIR}:/repo.git -w /repo.git chapel/chapel-gasnet:1.20.0 /bin/bash -c '
         apt-get update && apt-get install -y libfftw3-dev &&
         make ftt && ./target/example/NPB-FT/ft_transposed -nl 4'
+    - script: |
+        docker run -it -v ${TRAVIS_BUILD_DIR}:/repo.git -w /repo.git chapel/chapel-gasnet:1.22.0 /bin/bash -c '
+        apt-get update && apt-get install -y libfftw3-dev &&
+        make ftt && ./target/example/NPB-FT/ft_transposed -nl 4'


### PR DESCRIPTION
We keep the old 1.20 test as well, since we still have code for that.